### PR TITLE
Literal rework

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -23,7 +23,7 @@ pub enum Token {
 pub enum Expand {
     Literal(String),
     Var(String),
-    Tilde(String),
+    Tilde(Vec<Expand>),
     Brace(String, Action, Vec<Expand>),
 }
 
@@ -47,7 +47,8 @@ pub enum Action {
 impl Expand {
     pub fn get_name(self) -> String {
         match self {
-            Literal(s) | Var(s) | Tilde(s) | Brace(s, _, _) => s,
+            Literal(s) | Var(s) | Brace(s, _, _) => s,
+            Tilde(_) => panic!("you shouldn't be doing this"),
         }
     }
 }
@@ -75,6 +76,26 @@ pub enum Punct {
 // This representation makes it's functions very nice and easy,
 // but I'm not convinced that this is the most efficient/clean
 // the struct itself can be
+
+fn invalid_var(c: char) -> bool {
+    matches!(
+        c,
+        '&' | '!' | '|' | '<' | '>' | '"' | '=' | ':' | '}' | '+' | '-' | '?' | '$' | '\\'
+    ) || c.is_whitespace()
+}
+
+fn is_token_split(c: char) -> bool {
+    matches!(c, '&' | '!' | '|' | '<' | '>') || c.is_whitespace()
+}
+
+fn is_bracket(c: char) -> bool {
+    c == '}'
+}
+
+fn is_quote(c: char) -> bool {
+    c == '"'
+}
+
 pub struct Lexer {
     shell: Rc<RefCell<Shell>>,
     line: Peekable<IntoIter<char>>,
@@ -113,26 +134,53 @@ impl Lexer {
         }
     }
 
-    fn read_words(&mut self) -> Result<Vec<Expand>, String> {
-        let mut words = Vec::new();
-        while let Some(c) = self.peek_char() {
-            match c {
-                '$' => {
+    fn read_until<F>(&mut self, consume: bool, keep_going: bool, break_cond: F) -> Result<Vec<Expand>, String>
+    where
+        F: Fn(char) -> bool,
+    {
+        let mut expandables = Vec::new();
+        let mut cur_word = String::new();
+
+        let mut next = self.peek_char();
+        loop {
+            match next {
+                Some('\\') => {
+                    self.next_char();
+                    match self.next_char() {
+                        Some('\n') => self.advance_line()?,
+                        Some(c) => cur_word.push(c),
+                        None => (),
+                    }
+                }
+                Some(c) if break_cond(*c) => {
+                    if consume {
+                        self.next_char();
+                    }
+                    break;
+                }
+                Some('$') => {
+                    if !cur_word.is_empty() {
+                        expandables.push(Literal(cur_word));
+                        cur_word = String::new();
+                    }
                     self.next_char();
                     if let Some('{') = self.peek_char() {
-
                         fn get_action(null: bool, c: Option<char>) -> Option<Action> {
                             match c {
                                 Some('-') => Some(Action::UseDefault(null)),
                                 Some('=') => Some(Action::AssignDefault(null)),
                                 Some('?') => Some(Action::IndicateError(null)),
                                 Some('+') => Some(Action::UseAlternate(null)),
-                                _ => None, 
+                                _ => None,
                             }
                         }
 
                         self.next_char();
-                        let param = self.read_basic_literal();
+                        let param = if let Some(v) = self.read_until(false, false, invalid_var)?.pop() {
+                            Ok(v.get_name())
+                        } else {
+                            Err(String::from("bad substituion"))
+                        }?;
 
                         let action = match self.next_char() {
                             Some(':') => get_action(true, self.next_char()),
@@ -152,29 +200,50 @@ impl Lexer {
                                     Some(Action::RmSmallestPrefix)
                                 }
                             }
+                            Some(' ') => return Err(String::from("bad substitution")),
                             c => get_action(false, c),
                         };
 
                         if let Some(a) = action {
-                            let mut word = self.read_words()?;
-                            word.pop(); // Remove bracket at the end
-                            words.push(Brace(param, a, word));
+                            let word = self.read_until(true, true, is_bracket)?;
+                            expandables.push(Brace(param, a, word));
                         } else {
-                            words.push(Var(param));
+                            expandables.push(Var(param));
                         }
                     } else {
-                        words.push(Var(self.read_basic_literal()));
+                        let name = if let Some(v) = self.read_until(false, false, invalid_var)?.pop() {
+                            Ok(v.get_name())
+                        } else {
+                            Err(String::from("bad variable"))
+                        }?;
+                        expandables.push(Var(name));
                     }
                 }
-                '}' => {
-                    words.push(Literal(self.next_char().unwrap().to_string()));
-                    break
-                }
-                '~' => {
+                Some('~') => {
+                    if !cur_word.is_empty() {
+                        expandables.push(Literal(cur_word));
+                        cur_word = String::new();
+                    }
                     self.next_char();
-                    words.push(Tilde(self.read_literal()?));
+
+                    let tilde = self.read_until(false, false, invalid_var)?;
+                    expandables.push(Tilde(tilde));
                 }
-                '\'' => {
+                Some('"') => {
+                    if !cur_word.is_empty() {
+                        expandables.push(Literal(cur_word));
+                        cur_word = String::new();
+                    }
+                    self.next_char();
+
+                    let mut result = self.read_until(true, true, is_quote)?;
+                    if result.is_empty() {
+                        expandables.push(Literal(String::new()));
+                    } else {
+                        expandables.append(&mut result);
+                    }
+                }
+                Some('\'') => {
                     self.next_char();
                     let mut phrase = String::new();
                     loop {
@@ -184,77 +253,23 @@ impl Lexer {
                             None => self.advance_line()?,
                         }
                     }
-                    words.push(Literal(phrase));
+                    expandables.push(Literal(phrase));
                 }
-                '"' => {
-                    self.next_char();
-                    let mut phrase = String::new();
-                    loop {
-                        match self.next_char() {
-                            Some('"') => break,
-                            Some('\\') => match self.next_char() {
-                                Some('\n') => self.advance_line()?,
-                                Some(c) => phrase.push(c),
-                                None => (),
-                            },
-                            Some('$') => {
-                                words.push(Literal(phrase));
-                                words.push(Var(self.read_basic_literal()));
-                                phrase = String::new();
-                            }
-                            Some(c) => phrase.push(c),
-                            None => self.advance_line()?,
-                        }
+                Some(_) => cur_word.push(self.next_char().unwrap()),
+                None => {
+                    if keep_going {
+                        self.advance_line()?;
+                    } else {
+                        break
                     }
-                    words.push(Literal(phrase));
-                }
-                c if is_forbidden(*c) || c.is_whitespace() => break,
-                _ => words.push(Literal(self.read_literal()?)),
+                },
             }
+            next = self.peek_char();
         }
-        Ok(words)
-    }
-
-    fn read_literal(&mut self) -> Result<String, String> {
-        let mut phrase = String::new();
-        while let Some(c) = self.peek_char() {
-            match c {
-                '\\' => {
-                    self.next_char();
-                    match self.next_char() {
-                        Some('\n') => self.advance_line()?,
-                        Some(c) => phrase.push(c),
-                        None => break,
-                    }
-                }
-                '=' => {
-                    phrase.push(self.next_char().unwrap());
-                    break
-                }
-                c if is_forbidden(*c) || c.is_whitespace() => break,
-                _ => phrase.push(self.next_char().unwrap()),
-            }
+        if !cur_word.is_empty() {
+            expandables.push(Literal(cur_word));
         }
-        Ok(phrase)
-    }
-
-    fn read_basic_literal(&mut self) -> String {
-        let mut phrase = String::new();
-        while let Some(c) = self.peek_char() {
-            if (c.is_alphanumeric() || *c == '_') && !c.is_whitespace() {
-                phrase.push(self.next_char().unwrap());
-            } else if *c == '\\' {
-                self.next_char();
-                if let Some('\n') = self.peek_char() {
-                    let _ = self.advance_line();
-                } else {
-                    break
-                }
-            } else {
-                break
-            }
-        }
-        phrase
+        Ok(expandables)
     }
 
     // Of course, I still haven't added everything I'll need to yet
@@ -299,33 +314,34 @@ impl Lexer {
                 self.next_char();
                 Some(Token::Punct(Punct::RParen))
             }
-            Some(_) => {
-                match self.read_words() {
-                    Ok(w) => {
-                        println!("The words I got: {:?}", w);
-                        match &w[..] {
-                            [Literal(s), ..] if s.ends_with('=') && s.chars().filter(|c| c.is_numeric()).count() != s.len() - 1 => {
-                                let mut iter = w.into_iter();
-                                let mut name = iter.next().unwrap().get_name();
-                                name.pop();
-                                Some(Token::Assign(name, iter.collect()))
-                            }
-                            [Literal(s)] => {
-                                if let Ok(num) = s.parse::<u32>() {
-                                    Some(Token::Integer(num))
-                                } else {
-                                    Some(Token::Word(w))
-                                }
-                            }
-                            _ => Some(Token::Word(w)),
+            Some(_) => match self.read_until(false, false, is_token_split) {
+                Ok(w) => {
+                    println!("The words I got: {:?}", w);
+                    match &w[..] {
+                        [Literal(s), ..]
+                            if s.ends_with('=')
+                                && s.chars().filter(|c| c.is_numeric()).count() != s.len() - 1 =>
+                        {
+                            let mut iter = w.into_iter();
+                            let mut name = iter.next().unwrap().get_name();
+                            name.pop();
+                            Some(Token::Assign(name, iter.collect()))
                         }
-                    }
-                    Err(e) => {
-                        eprintln!("rush: {}", e);
-                        None
+                        [Literal(s)] => {
+                            if let Ok(num) = s.parse::<u32>() {
+                                Some(Token::Integer(num))
+                            } else {
+                                Some(Token::Word(w))
+                            }
+                        }
+                        _ => Some(Token::Word(w)),
                     }
                 }
-            }
+                Err(e) => {
+                    eprintln!("rush: {}", e);
+                    None
+                }
+            },
             None => None,
         }
     }
@@ -336,10 +352,6 @@ impl Iterator for Lexer {
     fn next(&mut self) -> Option<Token> {
         self.next_token()
     }
-}
-
-fn is_forbidden(c: char) -> bool {
-    matches!(c, '&' | '!' | '|' | '<' | '>' | '$' | '"' | '}' )
 }
 
 // TODO: More tests

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -374,7 +374,7 @@ impl Iterator for Lexer {
 // TODO: More tests
 #[cfg(test)]
 mod lexer_tests {
-    use super::{Lexer, Op, Token::*, Expand::*};
+    use super::{Expand::*, Lexer, Op, Token::*};
     use crate::helpers::Shell;
     use std::cell::RefCell;
     use std::rc::Rc;

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -265,7 +265,7 @@ impl Lexer {
         Ok(expandables)
     }
 
-    // You can accomplish this same thing with just the function above,
+    // You can accomplish this same thing with just the function above and some matching/unwrapping,
     // but I think this is cleaner
     fn read_raw_until<F>(&mut self, break_cond: F) -> Result<String, String>
     where

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -207,7 +207,8 @@ impl Parser {
         for word in expansions {
             match word {
                 Literal(s) => phrase.push_str(&s),
-                Tilde(s) => {
+                Tilde(word) => {
+                    let s = self.expand_word(word);
                     if s.is_empty() || s.starts_with('/') {
                         phrase.push_str(&env::var("HOME").unwrap());
                         phrase.push_str(&s);


### PR DESCRIPTION
Now, literals are read using a `read_until` function rather than the old patchy method that repeated a lot of code.

The main lexer function calls this function with essentially "read until forbidden char for word or whitespace." If this function encounters something like a `"`, it calls itself with "read until another `"`". Similar stuff for brace expansion - "read until another `}`". This makes this function quite a bit larger and somewhat more complex than the last method, but,
1. It actually works properly
2. I think its more understandable, and more versatile.